### PR TITLE
Resolved GLIBC not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.10-bullseye
+FROM ubuntu:22.04
 
 # Cloner le dépôt GitHub
 RUN apt update && apt install -y git
@@ -14,6 +14,7 @@ EXPOSE 6006
 EXPOSE 8080 
 
 # Installer les dépendances système et Python
+RUN apt install -y -qq python3.10 python3-pip python3.10-venv wget
 RUN apt install -y -qq ffmpeg aria2 unzip
 RUN pip3 install -r requirements.txt
 RUN pip3 install tensorboard


### PR DESCRIPTION
![image](https://github.com/PinkFloyd1213/RVC-AIO/assets/15166740/3fc7884f-e351-4399-9173-8754f1c36c3f)
Tensorboard server has dependencies on OS libc and this appears to cause something to crash.

Some systems still start normally, but problems occur with 20.04 Ubuntu hosts.
I replaced the docker source image because the problem seems to have been fixed in the latest Ubuntu!

![image](https://github.com/PinkFloyd1213/RVC-AIO/assets/15166740/8a64c8ba-d5c1-43e7-adbc-8a3dff7be385)

```yml
# docker-compose.yml
version: '3'
services:
  rvc-aio:
    build: .
    runtime: nvidia
    environment:
      - NVIDIA_VISIBLE_DEVICES=1
    ports:
      - 17865:7865
      - 16006:6006
      - 18080:8080
    volumes:
      - ./weights:/app/assets/weights
      - ./logs:/app/logs
      - ./audio:/app/audio
      - ./dataset:/app/dataset
```